### PR TITLE
Allow customizing the default target

### DIFF
--- a/fix-word.el
+++ b/fix-word.el
@@ -33,6 +33,30 @@
 
 (require 'cl-lib)
 
+(defgroup fix-word nil
+  "Convenient word transformation."
+  :group  'convenience
+  :tag    "Fix word"
+  :prefix "fix-word-"
+  :link   '(url-link :tag "GitHub" "https://github.com/mrkkrp/fix-word"))
+
+(defcustom fix-word-bounds-of-thing-function
+  #'bounds-of-thing-at-point
+  "Function to get the bounds of a thing at point.
+
+This variable lets you customize the way this package determines
+the bounds of a word."
+  :group 'fix-word
+  :type  'function)
+
+(defcustom fix-word-thing 'word
+  "The default transformation target of fix-word.
+
+This should be a symbol that can be passed as the argument to
+`bounds-of-thing-at-point' or its compatible function."
+  :group 'fix-word
+  :type 'symbol)
+
 ;;;###autoload
 (defun fix-word (fnc)
   "Lift function FNC into command that operates on words and regions.
@@ -127,7 +151,9 @@ the operation that many times."
 
 (defun fix-word--transform-word (fnc)
   "Transform the word at the point with function FNC."
-  (let ((bounds (bounds-of-thing-at-point 'word)))
+  (let ((bounds (funcall (or fix-word-bounds-of-thing-function
+                             'bounds-of-thing-at-point)
+                         (or fix-word-thing 'word))))
     (when bounds
       (cl-destructuring-bind (from . to) bounds
         (let ((origin (point))


### PR DESCRIPTION
I often wanted to upcase a symbol rather than a word, so I have added this option.

By setting `fix-word-thing` to `'symbol`, the fix-word commands work with a symbol rather than with a word when no active region is set.